### PR TITLE
Added album styles and fixed bug in avif_image

### DIFF
--- a/gensite/avif_exif/avif_image.py
+++ b/gensite/avif_exif/avif_image.py
@@ -93,11 +93,12 @@ def _extractTagPositions(f:FileExtent):
         if (tagName[0] == '/'):
             oldTagName, oldTagContentsOffset = stack.pop()
             if ("/" + oldTagName != tagName):
-                raise Exception("Mismatched tag names {} {}" % (oldTagName, tagName))
+                raise Exception(f"Mismatched tag names {oldTagName} {tagName}")
             endContentsOffset = f.baseFile.tell() - len(tagName) - 2
             results.append((oldTagName, oldTagContentsOffset, endContentsOffset - oldTagContentsOffset))
         else:
-            stack.append((tagName, f.baseFile.tell()))
+            if (tagName[-1] != '/'):    # ignore self closing tags
+                stack.append((tagName, f.baseFile.tell()))
     return results
 
 
@@ -160,6 +161,13 @@ class AvifImage:
         result = struct.unpack(">I", bytes)[0]
         return result
 
+    def read8byteLength(self):
+        bytes = self.file.read(8)
+        if len(bytes) < 4:
+            return None
+        result = struct.unpack(">Q", bytes)[0]
+        return result
+
     def readBoxHeader(self):
         pos = self.file.tell()
         length = self.read4ByteLength()
@@ -173,7 +181,7 @@ class AvifImage:
             return None
         if length == 1:
             # 64 bit length stored after the name
-            length = self.readUnsigned8Bytes()
+            length = self.read8byteLength()
             dataOffset = pos + 16
             dataLength = length - 16
 

--- a/template/default/css/tufte.css
+++ b/template/default/css/tufte.css
@@ -553,6 +553,25 @@ div.index div.groupheading {
 
 div.index div.group li {}
 
+/* special classes for the non-javascript fallback for the as-album custom element */
+as-album:not(.customelement) {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(150px, 1fr));
+  grid-auto-rows: 150px;
+  gap: 3px;
+  max-width: 100%;
+}
+
+as-album:not(.customelement) img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+}
+
+as-album:not(.customelement) a:link {
+  background: none;
+}
+
 
 @media (max-width: 760px),
 (orientation: portrait) {

--- a/utilities/thumbnail.py
+++ b/utilities/thumbnail.py
@@ -1,0 +1,15 @@
+# scratch code to generate markdown for a thumbnail collection
+
+l = []
+for i in Path("/Users/andrew/Documents/blog/2026/8/borneo_pictures/thumbs").iterdir():
+     l.append(i)
+
+a = "[![{{description}}]({{thumb}})]({{fullsized}})"
+
+for i in l:
+     t = a
+     thumb = pathlib.Path(*(i.parts[-3:]))
+     fullsize = pathlib.Path(thumb.parts[0], thumb.parts[2])
+     t = t.replace("{{thumb}}", str(thumb))
+     t = t.replace("{{fullsized}}", str(fullsize))
+     print(t)


### PR DESCRIPTION
Added styles for as-album, a custom web component for displaying photo albums.

Also fixed a silly bug in the avi_image class that would throw an exception if the embedded xml metadata had a self-closing tag (<likethis/>)
